### PR TITLE
Add electron as a dependency; npm start script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ Download the latest version corresponding to your system (32bit or 64bit) from [
 ##### Linux
 Download [electron](https://github.com/atom/electron/releases) for linux, download the source of the Explorer from [the release page](https://github.com/jfbouzereau/explorer/releases), copy the app folder into electron/resources, then run Electron.
 
-##Build from Source
+## Build from Source
 
 Should you want to go the Build & Deploy route -you'll require `node v6.1.0`, `npm@3.9.5` and `electron@1.2.5`
 - Download the Source files (`zip` or `tar.gz`) from the [the release page](https://github.com/jfbouzereau/explorer/releases).
 - Unzip
-- `cd exlorer-1.x`
+- `cd explorer-1.x`
 - `npm install`
 - `cd app`
 - `electron main.js`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 ## Introduction
 
 This Explorer allows to perform various statistical analyses and data mining operations in a very easy and intuitive way. As the name implies, this software aims at exploring data and getting quick insight of the order of magnitude of the observed objects. That's why it does focus on graphical representation and mouse driven operations, unlike the traditional statistical tools cluttered with numerous dialog boxes and lists with five decimal figures. You can, however, have the detailed numbers once your analysis is completed.
@@ -87,17 +86,30 @@ Download the latest version for darwin from [the release page](https://github.co
 Download the latest version corresponding to your system (32bit or 64bit) from [the release page](https://github.com/jfbouzereau/explorer/releases). The application is bundled into a single exe file, thanks to [BoxedApp Packer](http://www.boxedapp.com/boxedapppacker/index.html) .
 
 ##### Linux
-Download [electron](https://github.com/atom/electron/releases) for linux, download the source of the Explorer from [the release page](https://github.com/jfbouzereau/explorer/releases), copy the app folder into electron/resources, then run Electron.
+
+Follow the "Build from source" instructions below.
 
 ## Build from Source
 
-Should you want to go the Build & Deploy route -you'll require `node v6.1.0`, `npm@3.9.5` and `electron@1.2.5`
-- Download the Source files (`zip` or `tar.gz`) from the [the release page](https://github.com/jfbouzereau/explorer/releases).
-- Unzip
-- `cd explorer-1.x`
-- `npm install`
-- `cd app`
-- `electron main.js`
+Download and unzip the Source files (`zip` or `tar.gz`) from the [the release page](https://github.com/jfbouzereau/explorer/releases), or clone the repository:
+
+```sh
+git clone https://github.com/jfbouzereau/explorer.git
+```
+
+Enter the Explorer's directory with `cd explorer-1.x/app` (if you downloaded it from Releases) or `cd explorer/app` (if you cloned the repository).
+
+Install the dependencies: 
+
+```sh
+npm install
+```
+
+And launch the app:
+
+```sh
+npm start
+```
 
 ## Data loading
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ Follow the "Build from source" instructions below.
 
 ## Build from Source
 
+Should you want to go the Build & Deploy route -you'll require `node.js` (developed
+on v6.1.0, confirmed to work on v4.7.3) and `npm` (comes with node.js, developed using v3.9.5, confirmed to work on v2.15.11).
+
 Download and unzip the Source files (`zip` or `tar.gz`) from the [the release page](https://github.com/jfbouzereau/explorer/releases), or clone the repository:
 
 ```sh

--- a/app/package.json
+++ b/app/package.json
@@ -2,11 +2,17 @@
   "name": "Explorer",
   "version": "1.104.0",
   "main": "main.js",
+  "scripts": {
+    "start": "./node_modules/.bin/electron ."
+  },
   "dependencies": {
     "gapitoken": "^0.1.5",
     "mongodb": "^2.1.16",
     "request": "^2.69.0",
     "synaptic": "^1.0.2",
     "tedious": "^1.14.0"
+  },
+  "devDependencies": {
+    "electron": "^1.6.5"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,6 @@
     "tedious": "^1.14.0"
   },
   "devDependencies": {
-    "electron": "^1.6.5"
+    "electron": "1.2.x"
   }
 }


### PR DESCRIPTION
Hello,
This is such an exciting project! I've added electron as a development dependency so that users building from source do not have to install electron globally. I've also added an `npm start` script to go with it. This way, users do not have to manually copy the contents of the `app/` directory to the electron home, but can just run the app from its own directory. I've also updated the README to reflect the change.